### PR TITLE
Updated the Chart height

### DIFF
--- a/eco_indicator.py
+++ b/eco_indicator.py
@@ -97,7 +97,7 @@ def update_inky(conf: dict, inky_data: dict, demo: bool):
 
     # deal with scaling for newer SSD1608 pHATs
     if inky_display.resolution == (250, 122):
-        graph_y_unit = 2.3
+        graph_y_unit = 1.2
         graph_x_unit = 4 # needs to be int to avoid aliasing
         font_scale_factor = 1.2
         x_padding_factor = 1.25


### PR DESCRIPTION
On the new inky displays, the values used for the charts y height causes it to overlay the current value text when using agile_price mode
Adjusting this down makes the display more legible 

Before | After
--- | ---
![20210929_092210](https://user-images.githubusercontent.com/8202030/135352505-c6226e5d-859b-40db-897b-6d39b76bb768.jpg) | ![20210929_093102](https://user-images.githubusercontent.com/8202030/135352521-ee5bca4c-9272-401a-a49b-55288829e331.jpg)


