### PR TITLE
Added Inky Impression 7.3 support

### DIFF
--- a/eco_indicator.py
+++ b/eco_indicator.py
@@ -148,7 +148,7 @@ def update_inky_tracker(conf: dict, inky_data: dict, demo: bool):
     except TypeError as inky_version:
         raise TypeError("You need to update the Inky library to >= v1.1.0") from inky_version
 
-    img = Image.new("P", (inky_display.WIDTH, inky_display.HEIGHT))
+    img = Image.new("P", (inky_display.WIDTH, inky_display.HEIGHT), inky_display.WHITE)
     draw = ImageDraw.Draw(img)
 
     # deal with scaling for newer SSD1608 pHATs
@@ -162,6 +162,13 @@ def update_inky_tracker(conf: dict, inky_data: dict, demo: bool):
         font_scale_factor = 1
         x_scale_factor = 1
         y_scale_factor = 1
+
+    # Inky Impression 7.3
+    if inky_display.resolution == (800, 480):
+        font_scale_factor = 2
+        x_scale_factor = 3
+        y_scale_factor = 2
+        graph_x_width = 126 * x_scale_factor    
 
     today = datetime.now().date()
     print("Today is " + today.strftime("%a %-d %b %Y"))
@@ -524,6 +531,8 @@ def update_inky(conf: dict, inky_data: dict, demo: bool):
     x_pos = 130 * x_scale_factor
     y_pos = 10 * y_scale_factor + (3 * 18 * y_scale_factor)
     font = ImageFont.truetype(RobotoMedium, size=int(13 * font_scale_factor))
+
+
 
     if conf['Mode'] == "agile_import" or conf['Mode'] == "carbon":
         if '.' in str(low_slot_duration):

--- a/eco_indicator.py
+++ b/eco_indicator.py
@@ -319,8 +319,8 @@ def update_inky(conf: dict, inky_data: dict, demo: bool):
         inky_display = auto(ask_user=False, verbose=True)
     except TypeError as inky_version:
         raise TypeError("You need to update the Inky library to >= v1.1.0") from inky_version
-
-    img = Image.new("P", (inky_display.WIDTH, inky_display.HEIGHT))
+    #make an image framebuffer, explicit background colour of white (required for some Inky displays)
+    img = Image.new("P", (inky_display.WIDTH, inky_display.HEIGHT), inky_display.WHITE)
     draw = ImageDraw.Draw(img)
 
     # deal with scaling for newer SSD1608 pHATs
@@ -336,6 +336,13 @@ def update_inky(conf: dict, inky_data: dict, demo: bool):
         x_scale_factor = 1
         y_scale_factor = 1
         graph_x_width = 126 * x_scale_factor
+
+    # Inky Impression 7.3
+    if inky_display.resolution == (800, 480):
+        font_scale_factor = 2
+        x_scale_factor = 3
+        y_scale_factor = 2
+        graph_x_width = 126 * x_scale_factor    
 
     data_duration = conf['InkyPHAT']['DataDuration']
     graph_x_unit = graph_x_width / (data_duration * 2) # half hour slots!


### PR DESCRIPTION
Updated the code to change the scaling factors when an Inky Impression 7.3 from Pimoroni is detected. This also involves explicitly setting the background colour of the frame buffer to white - which should also work ok for the InkyPHAT.
<img width="727" alt="InkyImpression" src="https://github.com/jerbzz/pi-eco-indicator/assets/8467444/881c4bdd-e8a8-4d67-bf9e-dd2ad34f1e21">
